### PR TITLE
Return early in check_source_type to avoid invalid URI error when converting a file with spaces in the name

### DIFF
--- a/lib/libreconv.rb
+++ b/lib/libreconv.rb
@@ -58,10 +58,10 @@ module Libreconv
     end
 
     def check_source_type
-      is_file = File.exists?(@source) && !File.directory?(@source)
-      is_http = URI(@source).scheme == "http" && Net::HTTP.get_response(URI(@source)).is_a?(Net::HTTPSuccess)
-      is_https = URI(@source).scheme == "https" && Net::HTTP.get_response(URI(@source)).is_a?(Net::HTTPSuccess)
-      raise IOError, "Source (#{@source}) is neither a file nor an URL." unless is_file || is_http || is_https
+      return if File.exists?(@source) && !File.directory?(@source) #file
+      return if URI(@source).scheme == "http" && Net::HTTP.get_response(URI(@source)).is_a?(Net::HTTPSuccess) #http
+      return if URI(@source).scheme == "https" && Net::HTTP.get_response(URI(@source)).is_a?(Net::HTTPSuccess) #https
+      raise IOError, "Source (#{@source}) is neither a file nor an URL."
     end
   end
 end


### PR DESCRIPTION
I had problems when converting a file with spaces in the name since it isn't a valid URI. This fixes the issue by returning from the function once we know the source is valid