### PR TITLE
Support converting to other file formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Libreconv
 
-Convert office documents to PDF using LibreOffice / OpenOffice.
+Convert office documents using LibreOffice / OpenOffice to one of their supported formats.
 
 [![Code Climate](https://codeclimate.com/github/ricn/libreconv.png)](https://codeclimate.com/github/ricn/libreconv)
 [![Build Status](https://travis-ci.org/ricn/libreconv.png?branch=master)](https://travis-ci.org/ricn/libreconv)
@@ -41,6 +41,12 @@ Libreconv.convert('http://myserver.com/123/document.docx', '/Users/ricn/pdf_docu
 # Converts document.docx to document.pdf
 # If you for some reason can't have soffice in your PATH you can specifiy the file path to the soffice binary
 Libreconv.convert('document.docx', '/Users/ricn/pdf_documents', '/Applications/LibreOffice.app/Contents/MacOS/soffice')
+
+# Converts document.docx to my_document_as.html
+Libreconv.convert('document.docx', '/Users/ricn/pdf_documents/my_document_as.html', nil, 'html')
+
+# Converts document.docx to my_document_as.pdf using writer_pdf_Export filter
+Libreconv.convert('document.docx', '/Users/ricn/pdf_documents/my_document_as.pdf', nil, 'pdf:writer_pdf_Export')
 
 ```
 

--- a/lib/libreconv.rb
+++ b/lib/libreconv.rb
@@ -6,18 +6,19 @@ require "spoon"
 
 module Libreconv
 
-  def self.convert(source, target, soffice_command = nil)
-    Converter.new(source, target, soffice_command).convert
+  def self.convert(source, target, soffice_command = nil, convert_to = nil)
+    Converter.new(source, target, soffice_command, convert_to).convert
   end
 
   class Converter
     attr_accessor :soffice_command
 
-    def initialize(source, target, soffice_command = nil)
+    def initialize(source, target, soffice_command = nil, convert_to = nil)
       @source = source
       @target = target
       @target_path = Dir.tmpdir
       @soffice_command = soffice_command
+      @convert_to = convert_to || "pdf"
       determine_soffice_command
       check_source_type
 
@@ -29,10 +30,10 @@ module Libreconv
     def convert
       orig_stdout = $stdout.clone
       $stdout.reopen File.new('/dev/null', 'w')
-      pid = Spoon.spawnp(@soffice_command, "--headless", "--convert-to", "pdf", @source, "--outdir", @target_path)
+      pid = Spoon.spawnp(@soffice_command, "--headless", "--convert-to", @convert_to, @source, "--outdir", @target_path)
       Process.waitpid(pid)
       $stdout.reopen orig_stdout
-      target_tmp_file = "#{@target_path}/#{File.basename(@source, ".*")}.pdf"
+      target_tmp_file = "#{@target_path}/#{File.basename(@source, ".*")}.#{File.basename(@convert_to, ":*")}"
       FileUtils.cp target_tmp_file, @target
     end
 


### PR DESCRIPTION
Figured this may be useful to others as I need it now. It's meant to allow you to pass the same kind of options to `--convert-to output_file_extension[:output_filter_name]`. I've never actually used the `output_filter_name` bit but I tested it and it works fine.

I'm not the biggest fan of the ordering of the convert_to param coming after the soffice_command param but I figured it would be better not to break existing implementations.
